### PR TITLE
New config options:

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ The variables that can be passed to this role and a brief description about them
     interface: "enp0s8"                   # The network interface where heartbeat will be running on
     heartbeat_sharedip: "192.168.121.9"   # The shared ip for the heartbeat
 
+    The following variables are optional :
+
+    heartbeat_preferred_host:             # if wanting something different than the primary name
+    heartbeat_mcast_ip: "225.0.0.1"       # multicast ip address
+    auto_failback: "off|on|legacy"        # defaults to off
+    autojoin: "none|other|any"            # defaults to none
+    # array to add additional ressources.
+    # Each item is a complete line in the haresource file :
+    heartbeat_resources: [ 'linuxha1 192.168.85.3 httpd smb maid::vacuum',
+                           'linuxha1 192.168.85.3/27/192.168.85.16 httpd smb' ]
+
+
 Example Playbook
 ----------------
 

--- a/templates/ha.cf.j2
+++ b/templates/ha.cf.j2
@@ -17,7 +17,7 @@ deadtime 10
 #
 udpport        694
 bcast {{ interface }}
-mcast {{ interface }} 225.0.0.1 694 1 0
+mcast {{ interface }} {{ heartbeat_mcast_ip or '225.0.0.1' }} 694 1 0
 ucast {{ interface }} {{ target }}
 #       What interfaces to heartbeat over?
 udp     {{ interface }}
@@ -30,3 +30,11 @@ logfacility     local0
 #       node    nodename ...    -- must match uname -n
 node    {{ primary }}
 node    {{ backup }}
+#
+# auto-failback mode
+# 
+auto_failback {{ heatbeat_auto_failback | default('off', true) }}
+#
+# autojoin mode
+#
+autojoin {{ heartbeat_autojoin | default('none', true) }}

--- a/templates/haresources.j2
+++ b/templates/haresources.j2
@@ -1,1 +1,13 @@
-proxyatest {{ heartbeat_sharedip }}
+{# allow choosing a different hostname than the one showing as primary node in ha.cf #}
+{% if heartbeat_preferred_host is defined %}
+{{ heartbeat_preferred_host }} {{ heartbeat_sharedip }}
+{% else %}
+{{ primary }} {{ heartbeat_sharedip }}
+{% endif %}
+
+{# additionnal resources from optionnal heartbeat_resources array #}
+{% if heartbeat_resources is defined %}
+{% for resource in heartbeat_resources %}
+  {{ resource }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
- multicast ip
- preferred primary node name
- autojoin mode
- auto_failback mode
- additional resources

Optionnal variables in templates + update in the readme file. 
Also fix the hardcoded 'proxyatest' preferred node in haresource and 225.0.0.1 multicast ip address  that may not suit everyone.